### PR TITLE
ome/action-ansible-galaxy-publish@main, docker-network

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -42,6 +42,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: galaxy
-        uses: manics/action-ansible-galaxy-publish@main
+        uses: ome/action-ansible-galaxy-publish@main
         with:
           galaxy-api-key: ${{ secrets.GALAXY_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 IDR submission ticketing system
 ===============================
 
-[![Build Status](https://github.com/IDR/ansible-role-redmine-tracker/workflows/Build/badge.svg)](https://github.com/IDR/ansible-role-redmine-tracker/actions)
+[![Build Status](https://github.com/IDR/ansible-role-redmine-tracker/workflows/Molecule/badge.svg)](https://github.com/IDR/ansible-role-redmine-tracker/actions)
 
 This is an email ticketing system for handling IDR data submissions.
 The primary aim is to manage multiple complex email threads concerning data submissions to the IDR.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,6 @@ redmine_tracker_gmail_password: ""
 
 # Volume for redmine files
 redmine_tracker_docker_data_volume: redmine-data
+
+# Docker network for redmine
+redmine_tracker_docker_network: redmine

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,11 +24,19 @@
     name: docker-python
     state: present
 
+- name: redmine | docker network
+  become: true
+  docker_network:
+    name: "{{ redmine_tracker_docker_network }}"
+    state: present
+
 - name: redmine | docker run
   become: true
   docker_container:
     image: "{{ redmine_tracker_image }}"
     name: redmine
+    networks:
+      - name: "{{ redmine_tracker_docker_network }}"
     env:
       REDMINE_DB_POSTGRES: "{{ redmine_tracker_db_host }}"
       POSTGRES_ENV_POSTGRES_USER: "{{ redmine_tracker_db_user }}"


### PR DESCRIPTION
Also adds `redmine_tracker_docker_network`.

Requires
- [x] https://github.com/manics/action-ansible-galaxy-publish to be transferred to `ome`
- [ ] `GALAXY_API_KEY` secret

Tag: `0.0.2`, `0.1.0`, or `1.0.0`?